### PR TITLE
Build and live edit theme using gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ gem nexus .\unidata-jekyll-theme-0.0.1.gem
 
 ## Using the gem-based theme in your own documentation
 
+### Ruby
+
 Since the Unidata theme related gem files are hosted on our artifacts server, you will need to tell your Ruby installation that the artifacts server exists:
 
 ~~~sh
@@ -104,6 +106,12 @@ gem sources --add https://artifacts.unidata.ucar.edu/repository/gems/
 Once you have done this, you can generally follow the jekyll documentation regarding the installation and use of a [gem based theme](https://jekyllrb.com/docs/themes/#installing-a-theme).
 You will also need to make sure you include the `unidata-jekyll-plugin` gem.
 As this theme progresses, we will add more details about Unidata specific extensions to the theme, but for now, consider this a work in progress :-)
+
+### Java
+
+Unidata maintains a [gradle plugin](https://github.com/Unidata/unidata-jekyll-gradle) that utilizes JRuby to run Jekyll to build Jekyll sites using the Unidata theme maintained in this repository.
+While useful for Java based projects, it is also useful to those want to build documentation sets without installing the full Ruby stack.
+The only requirement for using the gradle plugin is Java version 8 or greater.
 
 ## Potentially useful utilities
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ Unidata maintains a [gradle plugin](https://github.com/Unidata/unidata-jekyll-gr
 While useful for Java based projects, it is also useful to those want to build documentation sets without installing the full Ruby stack.
 The only requirement for using the gradle plugin is Java version 8 or greater.
 
+The gradle build in this project uses the `unidata-jekyll-gradle` plugin.
+However, if you would like to use the plugin to build and serve the files in this repo, you must make a few edits prior to running `./gradlew buildJekyllSite` or `./gradlew serveJekyllSite`.
+1. edit `_config.yml` and comment out the line setting the theme (that is, add a  `#` to the beginning of the line `theme: unidata-jekyll-theme`)
+1. move the file `Gemfile` to a temporary directory.
+
+Note that both of these changes **must** be undone before making pull requests with changes or publishing artifacts.
+
 ## Potentially useful utilities
 
 The `utilities/` directory contains some potentially useful scripts for generating tags and pdf docs.

--- a/_config.yml
+++ b/_config.yml
@@ -39,7 +39,7 @@ port: 4000
 
 # these are the files and directories that jekyll will exclude from the build
 exclude:
-  - "build/"
+  - build/
   - gradle/
   - utils/
   - .idea/
@@ -50,6 +50,7 @@ exclude:
   - "gradlew*"
   - "*.gem"
   - "*.gemspec"
+  - "Gemfile.*"
   - README.md
   - .gitignore
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,30 @@
 plugins {
   id 'base'
   id 'maven-publish'
+  id 'edu.ucar.unidata.site.jekyll' version '0.0.1'
 }
 
 repositories {
   jcenter()
+  mavenCentral()
+  repositories {
+    maven {
+      // For Unidata Gradle Plugins
+      url 'https://artifacts.unidata.ucar.edu/repository/unidata-all/'
+    }
+  }
+}
+
+// use gemjar without the unidata jekyll theme and plugin gems bundled in
+configurations.gemjar {
+  resolutionStrategy.dependencySubstitution {
+    substitute(module('edu.ucar.unidata.site:jekyll-gems:0.0.1')).
+        using module('edu.ucar.unidata.site:jekyll-gems-minimum:0.0.1')
+  }
+}
+
+unidataJekyll {
+  sourceDirectory = file('.')
 }
 
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,9 @@
+pluginManagement {
+  repositories {
+    gradlePluginPortal()
+    maven {
+      // For Unidata Gradle Plugins
+      url 'https://artifacts.unidata.ucar.edu/repository/unidata-all/'
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the capability to build and live edit (serve) the Jekyll theme using gradle thanks to the new `unidata-jekyll-gradle` plugin. It requires two extra steps that must be undone after working on the theme, but it does work (see the changes to the README.md file for details).