### PR TITLE
Handle wrapping in navbar more robustly, leaving content area max width

### DIFF
--- a/assets/css/theme-unidata.css
+++ b/assets/css/theme-unidata.css
@@ -41,6 +41,11 @@ a[data-toggle="tooltip"] {
     cursor: default;
 }
 
+/* Prevent navbar wrapping to fit within content div width */
+.navbar > .container.topnavlinks {
+  box-sizing: content-box;
+}
+
 .navbar-inverse {
     background-color: #06778F;
     border-color: #034250;
@@ -180,20 +185,8 @@ div#toc ul li ul li::before {
     color: #7f8794;
 }
 
-/* page layout */
-.container {
-    max-width:100%;
-}
-
 #content {
     border-bottom: 4px solid #DCDCDC;
-}
-#footer {
-    margin-right: auto;
-    margin-left: auto;
-    padding-left: 15px;
-    padding-right: 15px;
-    max-width: 1000px;
 }
 
 


### PR DESCRIPTION
Changes were made to the layout in the 5.6 release in order to handle odd wrapping in the top nav bar. The changes had the effect of removing the maximum width on the content area. This change targets the top nav area more precisely, and reverts the content area styling.