### PR TITLE
Release v0.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
+gemspec :name => 'unidata-jekyll-plugins'
 gemspec :name => 'unidata-jekyll-theme'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# unidata-jekyll-theme
+# unidata-jekyll-theme and unidata-jekyll-plugins
 
 This repository contains a jekyll theme and associated plugins for Unidata documentation.
 This is a fork of the excellent [documentation-theme-jekyll](https://idratherbewriting.com/documentation-theme-jekyll) theme, with Unidata specific styling and extensions.
@@ -22,6 +22,7 @@ source 'https://rubygems.org'
 
 git 'https://github.com/Unidata/unidata-jekyll-theme.git', tag: 'v0.1.0' do
   gem 'unidata-jekyll-theme'
+  gem 'unidata-jekyll-plugins'
 end
 ```
 
@@ -54,7 +55,7 @@ The `DOCS_UID` environment variable is used to ensure the permissions of the ren
 
 #### A note on SRC_DIR
 
-Coordinating `SRC_DIR` and the bind mount containing the necessary files for a successful build can be tricky when the `includecodeblock` functionality of the theme is used.
+Coordinating `SRC_DIR` and the bind mount containing the necessary files for a successful build can be tricky when the `includecodeblock` functionality of the unidata-jekyll-plugins is used.
 
 For example, to serve the documentation of the netCDF-Java project for live editing, you would run the following from the root directory of the project:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Your `Gemfile` should, at a minimum, look like:
 ```shell
 source 'https://rubygems.org'
 
-git 'https://github.com/Unidata/unidata-jekyll-theme.git', tag: 'v0.1.0' do
+git 'https://github.com/Unidata/unidata-jekyll-theme.git', tag: 'v0.1.1' do
   gem 'unidata-jekyll-theme'
   gem 'unidata-jekyll-plugins'
 end
@@ -36,7 +36,7 @@ Check out the [Building and live editing](#Building-and-live-editing) section fo
 To serve the unidata-jekyll-theme using the unidata-jekyll-docs image, go to the top of this repository and run:
 
 ```shell
-docker run -it --rm -e SRC_DIR="/unidata-jekyll-theme" -v .:/unidata-jekyll-theme -p 4000:4000 docker.io/unidata/unidata-jekyll-docs:0.1.0 serve --livereload
+docker run -it --rm -e SRC_DIR="/unidata-jekyll-theme" -v .:/unidata-jekyll-theme -p 4000:4000 docker.io/unidata/unidata-jekyll-docs:0.1.1 serve --livereload
 ```
 
 The SRC_DIR environment variable must be set.
@@ -46,7 +46,7 @@ This should be a directory at or under the bind mount point.
 Similarly, to build using the unidata-jekyll-docs image:
 
 ```shell
-docker run -it --rm -e DOCS_UID=$(id -u) -e SRC_DIR="/unidata-jekyll-theme" -v .:/unidata-jekyll-theme -v ./_site:/site docker.io/unidata/unidata-jekyll-docs:0.1.0 build
+docker run -it --rm -e DOCS_UID=$(id -u) -e SRC_DIR="/unidata-jekyll-theme" -v .:/unidata-jekyll-theme -v ./_site:/site docker.io/unidata/unidata-jekyll-docs:0.1.1 build
 ```
 
 Note the additional bind mount `-v ./_site:/site` and the inclusion of `-e DOCS_UID=$(id -u)`.

--- a/basic_site_template/Gemfile
+++ b/basic_site_template/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-git 'https://github.com/Unidata/unidata-jekyll-theme.git', tag: 'v0.1.0' do
+git 'https://github.com/Unidata/unidata-jekyll-theme.git', tag: 'v0.1.1' do
   gem 'unidata-jekyll-theme'
   gem 'unidata-jekyll-plugins'
 end

--- a/basic_site_template/Gemfile
+++ b/basic_site_template/Gemfile
@@ -2,4 +2,5 @@ source 'https://rubygems.org'
 
 git 'https://github.com/Unidata/unidata-jekyll-theme.git', tag: 'v0.1.0' do
   gem 'unidata-jekyll-theme'
+  gem 'unidata-jekyll-plugins'
 end

--- a/docker/Gemfile
+++ b/docker/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-git 'https://github.com/Unidata/unidata-jekyll-theme.git', tag: 'v0.1.0' do
+git 'https://github.com/Unidata/unidata-jekyll-theme.git', tag: 'v0.1.1' do
   gem 'unidata-jekyll-theme'
   gem 'unidata-jekyll-plugins'
 end

--- a/docker/Gemfile
+++ b/docker/Gemfile
@@ -2,4 +2,5 @@ source 'https://rubygems.org'
 
 git 'https://github.com/Unidata/unidata-jekyll-theme.git', tag: 'v0.1.0' do
   gem 'unidata-jekyll-theme'
+  gem 'unidata-jekyll-plugins'
 end

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,11 +14,11 @@ Perform the following steps once a release has been made and tagged on GitHub:
 * run `build.sh` to create a local multi-platform image
 * tag the latest image with the release version for docker.io and ghcr:
   ```
-  docker image tag unidata-jekyll-docs:latest docker.io/unidata/unidata-jekyll-docs:0.1.0
-  docker image tag unidata-jekyll-docs:latest ghcr.io/unidata/unidata-jekyll-docs:0.1.0
+  docker image tag unidata-jekyll-docs:latest docker.io/unidata/unidata-jekyll-docs:0.1.1
+  docker image tag unidata-jekyll-docs:latest ghcr.io/unidata/unidata-jekyll-docs:0.1.1
   ```
 * push the new images
   ```
-  docker image push docker.io/unidata/unidata-jekyll-docs:0.1.0
-  docker image push ghcr.io/unidata/unidata-jekyll-docs:0.1.0
+  docker image push docker.io/unidata/unidata-jekyll-docs:0.1.1
+  docker image push ghcr.io/unidata/unidata-jekyll-docs:0.1.1
   ```

--- a/pages/mydoc/mydoc_about_ruby_gems_bundler.md
+++ b/pages/mydoc/mydoc_about_ruby_gems_bundler.md
@@ -39,7 +39,7 @@ jekyll-redirect-from = 0.10.0
 jekyll-sass-converter = 1.3.0
 jekyll-seo-tag = 1.3.2
 jekyll-sitemap = 0.10.0
-jekyll-textile-converter = 0.1.0
+jekyll-textile-converter = 0.1.1
 jemoji = 0.6.2
 kramdown = 1.10.0
 liquid = 3.0.6
@@ -150,7 +150,7 @@ GEM
       jekyll-sass-converter (= 1.3.0)
       jekyll-seo-tag (= 1.3.1)
       jekyll-sitemap (= 0.10.0)
-      jekyll-textile-converter (= 0.1.0)
+      jekyll-textile-converter (= 0.1.1)
       jemoji (= 0.5.1)
       kramdown (= 1.9.0)
       liquid (= 3.0.6)
@@ -194,7 +194,7 @@ GEM
     jekyll-seo-tag (1.3.1)
       jekyll (~> 3.0)
     jekyll-sitemap (0.10.0)
-    jekyll-textile-converter (0.1.0)
+    jekyll-textile-converter (0.1.1)
       RedCloth (~> 4.0)
     jekyll-watch (1.3.1)
       listen (~> 3.0)

--- a/unidata-jekyll-plugins.gemspec
+++ b/unidata-jekyll-plugins.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |spec|
     spec.name          = "unidata-jekyll-plugins"
     spec.version       = "0.0.4"
-    spec.required_ruby_version = ">= 3.4.5"
+    spec.required_ruby_version = ">= 4.0.1"
     spec.authors       = ["Unidata"]
     spec.email         = ["plaza@unidata.ucar.edu"]
 

--- a/unidata-jekyll-plugins.gemspec
+++ b/unidata-jekyll-plugins.gemspec
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+    spec.name          = "unidata-jekyll-plugins"
+    spec.version       = "0.0.4"
+    spec.required_ruby_version = ">= 3.4.5"
+    spec.authors       = ["Unidata"]
+    spec.email         = ["plaza@unidata.ucar.edu"]
+
+    spec.summary       = "A set of jekyll plugins for Unidata the Unidata Jekyll Theme."
+    spec.homepage      = "https://github.com/unidata/unidata-jekyll-theme"
+    spec.license       = "MIT"
+
+    all_files     = `git ls-files -z`.split("\x0")
+    spec.files       = all_files.grep(%r!^(_plugins)/!)
+    spec.require_paths = ["_plugins"]
+
+    spec.add_runtime_dependency "jekyll", "~> 4.4.1"
+  end

--- a/unidata-jekyll-theme.gemspec
+++ b/unidata-jekyll-theme.gemspec
@@ -11,9 +11,9 @@ Gem::Specification.new do |spec|
     spec.homepage      = "https://github.com/unidata/unidata-jekyll-theme"
     spec.license       = "MIT"
   
-    spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(_includes|_layouts|_plugins|assets|licenses|README|_config\.yml|version-info.json)!) }
-    spec.require_paths = ["_plugins"]
-
+    spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(_includes|_layouts|assets|licenses|README|_config\.yml|version-info.json)!) }
+  
     spec.add_runtime_dependency "jekyll", "~> 4.4.1"
     spec.add_runtime_dependency "logger", "~> 1.7.0"
+    spec.add_runtime_dependency "unidata-jekyll-plugins", "~> 0.0.4"
   end

--- a/unidata-jekyll-theme.gemspec
+++ b/unidata-jekyll-theme.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
     spec.name          = "unidata-jekyll-theme"
-    spec.version       = "0.1.0"
+    spec.version       = "0.1.1"
     spec.required_ruby_version = ">= 4.0.1"
     spec.authors       = ["Unidata"]
     spec.email         = ["plaza@unidata.ucar.edu"]


### PR DESCRIPTION
Add back the unidata-jekyll-plugin gemspec, as the plugin needs to ship
separate from the theme. Cut the v0.1.1 release.