### PR TITLE
Adjustments to page toc

### DIFF
--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -4,7 +4,7 @@
 $( document ).ready(function() {
   // Handler for .ready() called.
 
-$('#toc').toc({ minimumHeaders: 0, listType: 'ul', showSpeed: 0, headers: 'h2,h3,h4' });
+$('#toc').toc({ minimumHeaders: 0, listType: 'ul', showSpeed: 0, headers: '.container h2, .container h3, .container h4' });
 
 /* this offset helps account for the space taken up by the floating toolbar. */
 $('#toc').on('click', 'a', function() {

--- a/assets/css/theme-unidata.css
+++ b/assets/css/theme-unidata.css
@@ -216,6 +216,13 @@ div#toc ul li ul li::before {
     content: "\25E6\00A0   ";
 }
 
+/* hid the toc on smaller screens */
+@media (max-width: 992px) {
+    #tg-sb-sidebar-toc {
+    display: none;
+    }
+}
+
 /* info.html alert callout */
 .alert-more-info {
     background-color: #d9e0f7;

--- a/assets/css/theme-unidata.css
+++ b/assets/css/theme-unidata.css
@@ -180,11 +180,9 @@ li.sidebarTitle {
 
 /* table of contents */
 div#toc {
-    position: fixed;
-    top: 100px;
     margin-top: 40px;
     background: var(--uu-sidenav-background-color);
-    padding: 0.5em;
+    padding: 1em;
 }
 
 div#toc.fa-list-ul {


### PR DESCRIPTION
**Update TOC script to target container headers only**
-  Without this change, the javascript was pulling in the H2 header tags from the footer and including it in the page toc.

**Modify TOC positioning and padding**
- Adjust table of contents styling to not scroll with the page (causes issues for long toc that run into the footer section and become obscured).

**Add media query to hide TOC on small screens**
- Hide the table of contents on screens smaller than 992px